### PR TITLE
Fix ios start local video

### DIFF
--- a/ios/RCTTWVideoModule.m
+++ b/ios/RCTTWVideoModule.m
@@ -80,7 +80,6 @@ TVIVideoFormat *RCTTWVideoModuleCameraSourceSelectVideoFormatBySize(AVCaptureDev
 RCT_EXPORT_MODULE();
 
 - (void)dealloc {
-  NSLog(@"XCapture: dealloc");
   [self clearCameraInstance];
 }
 
@@ -166,14 +165,11 @@ RCT_EXPORT_METHOD(setRemoteAudioPlayback:(NSString *)participantSid enabled:(BOO
 }
 
 RCT_EXPORT_METHOD(startLocalVideo) {
-    NSLog(@"XCapture: js startLocalVideo");
 }
 
 - (void)startCameraCapture:(NSString *)cameraType {
-  NSLog(@"XCapture: Starting camera capture");
   if (self.camera == nil) {
-    NSLog(@"XCapture: Reinit camera");
-    self.camera = [[TVICameraSource alloc] initWithDelegate:self];
+    return;
   }
   AVCaptureDevice *camera;
     if ([cameraType isEqualToString:@"back"]) {
@@ -182,13 +178,11 @@ RCT_EXPORT_METHOD(startLocalVideo) {
     camera = [TVICameraSource captureDeviceForPosition:AVCaptureDevicePositionFront];
   }
 
-
-
   [self.camera startCaptureWithDevice:camera completion:^(AVCaptureDevice *device,
           TVIVideoFormat *startFormat,
           NSError *error) {
       if (error != nil) {
-        NSLog(@"XCapture: Start capture failed with error.\ncode = %lu error = %@", error.code, error.localizedDescription);
+        NSLog(@"Start capture failed with error.\ncode = %lu error = %@", error.code, error.localizedDescription);
       } else {
           for (TVIVideoView *renderer in self.localVideoTrack.renderers) {
             [self updateLocalViewMirroring:renderer];
@@ -203,7 +197,6 @@ RCT_EXPORT_METHOD(startLocalAudio) {
 }
 
 RCT_EXPORT_METHOD(stopLocalVideo) {
-    NSLog(@"XCapture: js stopLocalVideo");
     [self clearCameraInstance];
 }
 
@@ -212,7 +205,6 @@ RCT_EXPORT_METHOD(stopLocalAudio) {
 }
 
 RCT_EXPORT_METHOD(publishLocalVideo) {
-  NSLog(@"XCapture: publishing local video");
   if(self.localVideoTrack != nil){
     TVILocalParticipant *localParticipant = self.room.localParticipant;
     [localParticipant publishVideoTrack:self.localVideoTrack];
@@ -225,7 +217,6 @@ RCT_EXPORT_METHOD(publishLocalAudio) {
 }
 
 RCT_EXPORT_METHOD(unpublishLocalVideo) {
-  NSLog(@"XCapture: unpublishing local video");
   if(self.localVideoTrack != nil){
     TVILocalParticipant *localParticipant = self.room.localParticipant;
     [localParticipant unpublishVideoTrack:self.localVideoTrack];
@@ -247,12 +238,10 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 
 // set a default for setting local video enabled
 - (bool)_setLocalVideoEnabled:(bool)enabled {
-    NSLog(@"XCapture: _setLocalVideoEnabled default");
     return [self _setLocalVideoEnabled:enabled cameraType:@"front"];
 }
 
 - (bool)_setLocalVideoEnabled:(bool)enabled cameraType:(NSString *)cameraType {
-  NSLog(@"XCapture: _setLocalVideoEnabled with arg");
   if (self.localVideoTrack != nil) {
       [self.localVideoTrack setEnabled:enabled];
       return enabled;
@@ -262,7 +251,6 @@ RCT_REMAP_METHOD(setLocalAudioEnabled, enabled:(BOOL)enabled setLocalAudioEnable
 
 RCT_REMAP_METHOD(setLocalVideoEnabled, enabled:(BOOL)enabled setLocalVideoEnabledWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
-  NSLog(@"XCapture: js setLocalVideoEnabled");
   bool result = [self _setLocalVideoEnabled:enabled];
   resolve(@(result));
 }
@@ -397,16 +385,12 @@ RCT_EXPORT_METHOD(getStats) {
 }
 
 RCT_EXPORT_METHOD(connect:(NSString *)accessToken roomName:(NSString *)roomName enableAudio:(BOOL *)enableAudio enableVideo:(BOOL *)enableVideo encodingParameters:(NSDictionary *)encodingParameters enableNetworkQualityReporting:(BOOL *)enableNetworkQualityReporting dominantSpeakerEnabled:(BOOL *)dominantSpeakerEnabled cameraType:(NSString *)cameraType) {
-    NSLog(@"XCapture: js connect");
-
-  // Moved from startLocalVideo
   TVICameraSourceOptions *options = [TVICameraSourceOptions optionsWithBlock:^(TVICameraSourceOptionsBuilder * _Nonnull builder) {
 
   }];
   self.camera = [[TVICameraSource alloc] initWithOptions:options delegate:self];
   self.localVideoTrack = [TVILocalVideoTrack trackWithSource:self.camera enabled:enableVideo name:@"camera"];
   [self startCameraCapture:cameraType]; 
-  // end Moved from startLocalVideo
 
   if (self.localAudioTrack) {
     [self.localAudioTrack setEnabled:enableAudio];
@@ -458,13 +442,11 @@ RCT_EXPORT_METHOD(sendString:(nonnull NSString *)message) {
 }
 
 RCT_EXPORT_METHOD(disconnect) {
-  NSLog(@"XCapture: js disconnect");
   [self clearCameraInstance];
   [self.room disconnect];
 }
 
 - (void)clearCameraInstance {
-    NSLog(@"XCapture: clearCameraInstance");
     // We are done with camera
     if (self.camera) {
         [self.camera stopCapture];


### PR DESCRIPTION
The camera instance was being cleared/reinitialized on local video toggle. This caused a race condition because clearing the camera instance is async. It should only be created on init and cleared on cleanup.

This merges the `startLocalVideo` logic into `connect`, and makes `setLocalVideo` only toggle the local video track rather than the camera.

An additional fix could include replacing `stopCapture` to `stopCaptureWithCompletion` and using a flag or event to prevent starting while the camera is stopping. A similar check could be added for publishing/unpublishing. This fixes the majority of our issues, so that can be addressed later.